### PR TITLE
[Refactor, Design] 모바일 메뉴 서랍 컴포넌트 분리 및 디자인 오류 수정

### DIFF
--- a/src/shared/components/Menu.tsx
+++ b/src/shared/components/Menu.tsx
@@ -167,7 +167,12 @@ const Menu = ({ mode = 'light', ...props }: MenuProps) => {
         </div>
 
         {/* 햄버거 메뉴 아이콘 : mobile */}
-        <button className="cursor-pointer md:hidden" onClick={() => setDrawerOpen(true)}>
+        <button
+          className="cursor-pointer md:hidden"
+          onClick={() => setDrawerOpen(true)}
+          aria-label="메뉴 서랍 열기"
+          aria-expanded={drawerOpen}
+          aria-controls="mobile-drawer">
           <RiMenuLine className={iconItemClasses} />
         </button>
         {drawerOpen && <MobileDrawer setDrawerOpen={setDrawerOpen} mobileMenuColor={mobileMenuColor} />}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- close #17

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 모바일 메뉴 서랍 컴포넌트 분리
- 모바일 메뉴 서랍 - 열고 닫히는 transform 구현
- hover 색상 변경으로 수정 (기존 - underline)

## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| 모바일 메뉴 서랍 |
| --- |
| ![화면 기록](https://github.com/user-attachments/assets/482f2b5d-8f64-4883-a661-997a9bb88cb5) |

| hover 색상 변경으로 수정 |
| --- |
| <img width="1457" height="93" alt="image" src="https://github.com/user-attachments/assets/215b2794-1f9d-4ef4-8b26-bf1b625234f0" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모바일 메뉴가 드로어 패턴으로 재설계되었습니다.
  * 햄버거 버튼으로 열고 내부 닫기 버튼으로 닫을 수 있습니다.
  * 열기/닫기 시 부드러운 애니메이션과 언마운트 전 300ms 지연이 적용됩니다.
  * ESC로 닫기, 바디 스크롤 잠금, 모바일 메뉴 색상 테마(기본/호버) 등 모바일 사용성 개선이 포함됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->